### PR TITLE
build: Erase package_cache upon flashing

### DIFF
--- a/tools/releasetools/common.py
+++ b/tools/releasetools/common.py
@@ -2862,6 +2862,9 @@ class BlockDifference(object):
                 new_data_name=new_data_name, code=code))
     script.AppendExtra(script.WordWrap(call))
 
+    call = ('delete_recursive("/data/system/package_cache");')
+    script.AppendExtra(script.WordWrap(call))
+
   def _HashBlocks(self, source, ranges): # pylint: disable=no-self-use
     data = source.ReadRangeSet(ranges)
     ctx = sha1()


### PR DESCRIPTION
To avoid the resources bug when dirty flashing

Signed-off-by: Joey Huab <joey@evolution-x.org>
Change-Id: I95d89bffe959056dc08d71b3d3aede936ad9c5fc